### PR TITLE
Fix link to documentation at docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rust bindings to PC/SC for smart card communication.
 - Works on all major operating systems.
 - Mostly zero overhead.
 
-See the [Documentation](https://docs.rs/pcsc) for more details.
+See the [Documentation](https://docs.rs/crate/pcsc) for more details.
 
 See the examples directory for some common tasks.
 


### PR DESCRIPTION
But it seems docs.rs can't build the crate (I add a comment in https://github.com/onur/docs.rs/issues/23)