### PR TITLE
SCARDCONTEXT and SCARDHANDLE are pointers on Windows platforms

### DIFF
--- a/pcsc-sys/src/lib.rs
+++ b/pcsc-sys/src/lib.rs
@@ -41,7 +41,14 @@ pub type LONG = i32;
 #[cfg(target_os = "macos")]
 pub type ULONG = u32;
 
+#[cfg(target_os = "windows")]
+pub type SCARDCONTEXT = usize;
+#[cfg(target_os = "windows")]
+pub type SCARDHANDLE = usize;
+
+#[cfg(not(target_os = "windows"))]
 pub type SCARDCONTEXT = LONG;
+#[cfg(not(target_os = "windows"))]
 pub type SCARDHANDLE = LONG;
 
 pub const SCARD_S_SUCCESS: LONG = 0x0000_0000;

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -571,7 +571,7 @@ impl Context {
         scope: Scope,
     ) -> Result<Context, Error> {
         unsafe {
-            let mut ctx: ffi::SCARDCONTEXT = DUMMY_LONG;
+            let mut ctx: ffi::SCARDCONTEXT = DUMMY_LONG as ffi::SCARDCONTEXT;
 
             try_pcsc!(ffi::SCardEstablishContext(
                 scope as DWORD,
@@ -749,7 +749,7 @@ impl Context {
         preferred_protocols: Protocols,
     ) -> Result<Card, Error> {
         unsafe {
-            let mut handle: ffi::SCARDHANDLE = DUMMY_LONG;
+            let mut handle: ffi::SCARDHANDLE = DUMMY_LONG as ffi::SCARDHANDLE;
             let mut raw_active_protocol: DWORD = DUMMY_DWORD;
 
             try_pcsc!(ffi::SCardConnect(


### PR DESCRIPTION
The `SCARDCONTEXT` and `SCARDHANDLE` are `LONG` only in pcsclite implementations.

For winscard, these are `ULONG_PTR`, so it is 32 bits on 32 bits platforms but 64 on 64bits platforms. That's why it is working on windows 32 but failing on windows 64 bits as reported in #6 

I didn't find an official source of winscard.h unfortunately, I used mingw header:
https://sourceforge.net/p/mingw/mingw-org-wsl/ci/4.1-dev/tree/include/winscard.h

Fixes #6