### PR TITLE
Allow to bypass pkgconfig

### DIFF
--- a/pcsc-sys/build.rs
+++ b/pcsc-sys/build.rs
@@ -20,15 +20,20 @@ fn main() {
         }
 
         _ => {
-            pkg_config::Config::new()
-                .atleast_version("1")
-                .probe("libpcsclite")
-                .expect(&format!(
-                    r#"Could not find a PCSC library.
+            if let Ok(lib_dir) = env::var("PCSC_LIB_DIR") {
+                println!("cargo:rustc-link-search=native={}", lib_dir);
+                println!("cargo:rustc-link-lib={}", env::var("PCSC_LIB_NAME").unwrap_or("pcsclite".to_string()));
+            } else {
+                pkg_config::Config::new()
+                    .atleast_version("1")
+                    .probe("libpcsclite")
+                    .expect(&format!(
+                        r#"Could not find a PCSC library.
 For the target OS `{}`, I tried to use pkg-config to find libpcsclite.
 Do you have pkg-config and libpcsclite configured for this target?"#,
-                    target_os
-                ));
+                        target_os
+                    ));
+            }
         }
     };
 }


### PR DESCRIPTION
When cross-compiling, it can be hard to configure pkg-config to search in the right place.

This PR add the possibility to manually specify the location of headers and libraries using `PCSCLITE_LIB_DIR` and `PCSCLITE_INCLUDE_DIR` environment variables.

This is done this way by the [OpenSSL](https://github.com/sfackler/rust-openssl) crate.