### PR TITLE
Add current_state getter

### DIFF
--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -1012,7 +1012,7 @@ impl ReaderState {
         &self.inner.rgbAtr[0..self.inner.cbAtr as usize]
     }
     
-    /// The last current state.
+    /// The last current state that was set.
     pub fn current_state(&self) -> State {
         State::from_bits_truncate(self.inner.dwCurrentState)
     }

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -1011,6 +1011,11 @@ impl ReaderState {
     pub fn atr(&self) -> &[u8] {
         &self.inner.rgbAtr[0..self.inner.cbAtr as usize]
     }
+    
+    /// The last current state.
+    pub fn current_state(&self) -> State {
+        State::from_bits_truncate(self.inner.dwCurrentState)
+    }
 
     /// The last reported state.
     pub fn event_state(&self) -> State {


### PR DESCRIPTION
This allow check for if card was already present or not.
In windows we receive change event on every use card. By compare `current_state` present and `event_state` present we can detect if card was just change inuse state