### PR TITLE
Support Protocol::ANY in connect

### DIFF
--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -599,7 +599,7 @@ fn get_protocol_pci(protocol: Protocol) -> &'static ffi::SCARD_IO_REQUEST {
             Protocol::T0 => &ffi::g_rgSCardT0Pci,
             Protocol::T1 => &ffi::g_rgSCardT1Pci,
             Protocol::RAW => &ffi::g_rgSCardRawPci,
-            Protocol::ANY => &ffi::g_rgSCardT0Pci | &ffi::g_rgSCardT1Pci,
+            Protocol::ANY => &(ffi::g_rgSCardT0Pci | ffi::g_rgSCardT1Pci),
         }
     }
 }

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -221,6 +221,7 @@ pub enum Protocol {
     T0 = ffi::SCARD_PROTOCOL_T0 as u32,
     T1 = ffi::SCARD_PROTOCOL_T1 as u32,
     RAW = ffi::SCARD_PROTOCOL_RAW as u32,
+    ANY = ffi::SCARD_PROTOCOL_ANY as u32,
 }
 
 impl Protocol {
@@ -230,6 +231,7 @@ impl Protocol {
             ffi::SCARD_PROTOCOL_T0 => Some(Protocol::T0),
             ffi::SCARD_PROTOCOL_T1 => Some(Protocol::T1),
             ffi::SCARD_PROTOCOL_RAW => Some(Protocol::RAW),
+            ffi::SCARD_PROTOCOL_ANY => Some(Protocol::ANY),
             // This should not be possible, since we only allow to select
             // from Protocol's variants (or none).
             _ => panic!("impossible protocol: {:#x}", raw),

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -599,6 +599,7 @@ fn get_protocol_pci(protocol: Protocol) -> &'static ffi::SCARD_IO_REQUEST {
             Protocol::T0 => &ffi::g_rgSCardT0Pci,
             Protocol::T1 => &ffi::g_rgSCardT1Pci,
             Protocol::RAW => &ffi::g_rgSCardRawPci,
+            Protocol::ANY => &ffi::g_rgSCardT0Pci | &ffi::g_rgSCardT1Pci,
         }
     }
 }


### PR DESCRIPTION
This change fixes a panic when `SCardReconnect` accepts as the `active_protocol` the `preferred_protocols` of `T0 | T1` (`ANY`). 

The `Protocol::from_raw` call when parsing the `active_protocol` panics with "impossible protocol".