### PR TITLE
Make ffi public again

### DIFF
--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -109,7 +109,7 @@ use std::ptr::{null, null_mut};
 use std::sync::Arc;
 
 use bitflags::bitflags;
-use pcsc_sys as ffi;
+pub use pcsc_sys as ffi;
 
 use ffi::{DWORD, LONG};
 


### PR DESCRIPTION
With the release of 2.8.1 the ffi became private breaking users of the crate