### PR TITLE
fix macos SCardControl function link to SCardControl132 which has ctl…

### DIFF
--- a/pcsc-sys/src/lib.rs
+++ b/pcsc-sys/src/lib.rs
@@ -396,6 +396,7 @@ extern "system" {
         pcbRecvLength: *mut DWORD,
     ) -> LONG;
 
+    #[cfg_attr(target_os = "macos", link_name = "SCardControl132")]
     pub fn SCardControl(
         hCard: SCARDHANDLE,
         dwControlCode: DWORD,


### PR DESCRIPTION
Funcation SCardControl in macos hasn't controlcode parameter.