### PR TITLE
Bump bitflags to `2.4.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, windows-2019, macos-12]
         toolchain: [stable]
         include:
-          - {os: ubuntu-22.04, toolchain: '1.38.0'}
+          - {os: ubuntu-22.04, toolchain: '1.56.0'}
           - {os: ubuntu-22.04, toolchain: beta}
           - {os: ubuntu-22.04, toolchain: nightly}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "pcsc"
@@ -25,6 +25,6 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.9"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"

--- a/pcsc-sys/Cargo.toml
+++ b/pcsc-sys/Cargo.toml
@@ -15,4 +15,4 @@ rust-version = "1.38"
 edition = "2018"
 
 [build-dependencies]
-pkg-config = "0.3.9"
+pkg-config = "0.3.30"

--- a/pcsc/Cargo.toml
+++ b/pcsc/Cargo.toml
@@ -14,5 +14,5 @@ rust-version = "1.38"
 edition = "2018"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2"
 pcsc-sys = { version = "1.2.0", path = "../pcsc-sys" }

--- a/pcsc/Cargo.toml
+++ b/pcsc/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/bluetech/pcsc-rust"
 homepage = "https://github.com/bluetech/pcsc-rust"
 readme = "../README.md"
 authors = ["Ran Benita <ran@unusedvar.com>"]
-rust-version = "1.38"
+rust-version = "1.56"
 edition = "2018"
 
 [dependencies]

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -124,6 +124,7 @@ const DUMMY_DWORD: DWORD = 0xdead_beef;
 
 bitflags! {
     /// A mask of the state a card reader.
+    #[derive(Debug)]
     pub struct State: DWORD {
         const UNAWARE = ffi::SCARD_STATE_UNAWARE;
         const IGNORE = ffi::SCARD_STATE_IGNORE;
@@ -148,6 +149,7 @@ bitflags! {
     /// On Windows, Status always has exactly one bit set, and the bit values do
     /// not correspond to underlying PC/SC constants. This allows Status to be
     /// used in the same way across all platforms.
+    #[derive(Debug)]
     pub struct Status: DWORD {
         const UNKNOWN = {
             #[cfg(not(target_os = "windows"))] { ffi::SCARD_UNKNOWN }


### PR DESCRIPTION
This removes duplicate dependencies in the tree of crates depending on pcsc.

Sadly this also raises the MSRV to 1.56. I would tend to believe this is acceptable.