### PR TITLE
pcsc: switch to bitflags 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-22.04, windows-2022, macos-14]
         toolchain: [stable]
         include:
-          - {os: ubuntu-22.04, toolchain: '1.38.0'}
+          - {os: ubuntu-22.04, toolchain: '1.56.0'}
           - {os: ubuntu-22.04, toolchain: beta}
           - {os: ubuntu-22.04, toolchain: nightly}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "bitflags"
-version = "1.2.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "pcsc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["pcsc", "pcsc-sys"]
+resolver = "2"

--- a/pcsc-sys/Cargo.toml
+++ b/pcsc-sys/Cargo.toml
@@ -11,8 +11,8 @@ homepage = "https://github.com/bluetech/pcsc-rust"
 authors = ["Ran Benita <ran@unusedvar.com>"]
 build = "build.rs"
 links = "pcsc"
-rust-version = "1.38"
-edition = "2018"
+rust-version = "1.56"
+edition = "2021"
 
 [build-dependencies]
 pkg-config = "0.3.9"

--- a/pcsc/Cargo.toml
+++ b/pcsc/Cargo.toml
@@ -10,9 +10,9 @@ repository = "https://github.com/bluetech/pcsc-rust"
 homepage = "https://github.com/bluetech/pcsc-rust"
 readme = "../README.md"
 authors = ["Ran Benita <ran@unusedvar.com>"]
-rust-version = "1.38"
-edition = "2018"
+rust-version = "1.56"
+edition = "2021"
 
 [dependencies]
-bitflags = "1.2.1"
+bitflags = "2"
 pcsc-sys = { version = "1.2.0", path = "../pcsc-sys" }

--- a/pcsc/src/lib.rs
+++ b/pcsc/src/lib.rs
@@ -124,6 +124,8 @@ const DUMMY_DWORD: DWORD = 0xdead_beef;
 
 bitflags! {
     /// A mask of the state a card reader.
+    // Derives to keep backward compat with bitflags 1.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct State: DWORD {
         const UNAWARE = ffi::SCARD_STATE_UNAWARE;
         const IGNORE = ffi::SCARD_STATE_IGNORE;
@@ -140,6 +142,14 @@ bitflags! {
     }
 }
 
+// Backward compat with bitflags 1.
+impl State {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    pub unsafe fn from_bits_unchecked(bits: DWORD) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 bitflags! {
     /// A mask of the status of a card in a card reader.
     ///
@@ -148,6 +158,8 @@ bitflags! {
     /// On Windows, Status always has exactly one bit set, and the bit values do
     /// not correspond to underlying PC/SC constants. This allows Status to be
     /// used in the same way across all platforms.
+    // Derives to keep backward compat with bitflags 1.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Status: DWORD {
         const UNKNOWN = {
             #[cfg(not(target_os = "windows"))] { ffi::SCARD_UNKNOWN }
@@ -197,6 +209,12 @@ impl Status {
         #[cfg(not(target_os = "windows"))]
         Status::from_bits_truncate(raw_status)
     }
+
+    // Backward compat with bitflags 1.
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    pub unsafe fn from_bits_unchecked(bits: DWORD) -> Self {
+        Self::from_bits_retain(bits)
+    }
 }
 
 /// How a reader connection is shared.
@@ -239,12 +257,22 @@ impl Protocol {
 
 bitflags! {
     /// A mask of possible communication protocols.
+    // Derives to keep backward compat with bitflags 1.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Protocols: DWORD {
         const UNDEFINED = ffi::SCARD_PROTOCOL_UNDEFINED;
         const T0 = ffi::SCARD_PROTOCOL_T0;
         const T1 = ffi::SCARD_PROTOCOL_T1;
         const RAW = ffi::SCARD_PROTOCOL_RAW;
         const ANY = ffi::SCARD_PROTOCOL_ANY;
+    }
+}
+
+// Backward compat with bitflags 1.
+impl Protocols {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    pub unsafe fn from_bits_unchecked(bits: DWORD) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 


### PR DESCRIPTION
bitflags releases a major version, but we use it in the public interface, so upgrading is a breaking change. However, the bitflags changelog provides guidance on how to keep 2 mostly compatible with 1: https://github.com/bitflags/bitflags/blob/main/CHANGELOG.md#200

This is not perfect, there is still some chance of breaking dependents, but I think/hope it is OK. I think it's better than sticking with 1 only or bumping pcsc major.

The MSRV is bumped to match bitflags.